### PR TITLE
feat: improve Dockerfile and include basic usage documentation

### DIFF
--- a/Docker.md
+++ b/Docker.md
@@ -1,0 +1,17 @@
+# Build
+```shell
+docker build -t $USER/ionscale:dev-latest -t $USER/ionscale:dev-$(git rev-parse --short HEAD) . -f Dockerfile
+```
+This will build a docker image tagged with your USER and Labels with the current commit and "dev-latest"
+
+# Run
+```shell
+docker network create --attachable net-ionscale
+docker run -d --name ionscale --net net-ionscale -v $(pwd)/conf:/data/conf -v $(pwd)/db:/data/db -v $(pwd)/policies:/data/policies $USER/ionscale:dev-latest
+```
+This will run our newly crafted docker image on an isolated network with 3 volumes: configurations, database, and policies.  
+The default entrypoint is `/usr/local/bin/ionscale`  
+The default command run is `server --config /data/conf/ionscale.yaml`  
+This yields `/usr/local/bin/ionscale server --config /data/conf/ionscale.yaml`
+Ports can be exposed by adding `-p <external>:<internal>/<proto>`  
+Default configs would be `-p 8080:8080/tcp -p 8443:8443/tcp -p 8081:8081/tcp` but are left as an exercise to the user

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,16 @@
-FROM alpine:3.15.4
-COPY ionscale /usr/local/bin/ionscale
-ENTRYPOINT ["ionscale"]
+FROM golang:1.18-alpine3.15 AS build
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . ./
+RUN go build -ldflags '-s -w' ./cmd/ionscale
+
+FROM alpine:3.15
+WORKDIR /app
+COPY --from=build /app/ionscale /usr/local/bin/ionscale
+VOLUME ["/data/conf","/data/policies","/data/db"]
+ENTRYPOINT ["/usr/local/bin/ionscale"]
+CMD ["server", "--config", "/data/conf/ionscale.yaml"]


### PR DESCRIPTION
- Improves Dockerfile by using a multi-stage build sequence to improve layer caching.
- Pins against go@1.18 and alpine@3.15
- Volumes support
- Default command
- Basic Documentation and Usage